### PR TITLE
Specify full argument name

### DIFF
--- a/R/cran_check_table.R
+++ b/R/cran_check_table.R
@@ -37,7 +37,7 @@ process_cran_table <- function(tbl) {
   ctbl <- stats::reshape(ctbl,
     idvar = c("package"),
     timevar = "status", direction = "wide",
-    v.name = "Freq"
+    v.names = "Freq"
   )
   names(ctbl) <- gsub("Freq\\.", "", names(ctbl))
   names(ctbl) <- tolower(names(ctbl))


### PR DESCRIPTION
Eliminates this warning for people who work with partial match warnings turned on:

```
Warning message:
In stats::reshape(ctbl, idvar = c("package"), timevar = "status",  :
  partial argument match of 'v.name' to 'v.names'
```