### PR TITLE
Main

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -1,6 +1,6 @@
 on:
-##  schedule:
-##    - cron:  '25 5 * * *'
+  schedule:
+    - cron:  '25 5 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -1,6 +1,6 @@
 on:
-  schedule:
-    - cron:  '25 5 * * *'
+##  schedule:
+##    - cron:  '25 5 * * *'
   push:
     branches:
       - main

--- a/tests/testthat/test-incoming.R
+++ b/tests/testthat/test-incoming.R
@@ -1,6 +1,6 @@
 test_that("Documentation is correct", {
   skip_on_cran()
-  skip_on_travis()
+  skip_on_ci()
 
   ## make sure all folders investigated are correct
   expect_silent(res <- cran_incoming())
@@ -29,7 +29,7 @@ test_that("only character strings are provided", {
 
 test_that("filtering works", {
   skip_on_cran()
-  skip_on_travis()
+  skip_on_ci()
   res <- cran_incoming()
   pkg_test <- sample(res$package, 5L)
   res_test <- cran_incoming(pkg = pkg_test)
@@ -38,7 +38,7 @@ test_that("filtering works", {
 
 test_that("specifying folders works", {
   skip_on_cran()
-  skip_on_travis()
+  skip_on_ci()
   res <- cran_incoming(folders = "archive")
   expect_true(nrow(res) > 1 && all(res$cran_folder == "archive"))
   res2 <- cran_incoming(folders = c("inspect", "pending"))


### PR DESCRIPTION
With the move to GitHub actions I changed `skip_on_travis()` to `skip_on_ci()` throughout.  I also commented out the scheduled `cron` test in the workflow (seems like overkill).

I am still having problems passing devtools tests; I think these may be due to sporadic network access problems? Ran `devtools::test()` twice in a row. First time results were

```
[ FAIL 4 | WARN 1 | SKIP 1 | PASS 100 ]
```

second time was

```
[ FAIL 1 | WARN 1 | SKIP 1 | PASS 110 ]
```

I don't know if there's a way to make the tests more robust or not (I also noticed that on GitHub actions a different subset of platforms would fail each time ...