### PR TITLE
add machinery to include packages in special/ subdirectories

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: foghorn
 Title: Summarize CRAN Check Results in the Terminal
-Version: 1.6.1
+Version: 1.6.2
 Authors@R: 
     c(person(given = "Francois",
              family = "Michonneau",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# foghorn 1.6.2
+
+## New Features
+
+* `cran_incoming()` now includes packages that are being checked in `special/`
+  subdirectories of the CRAN incoming queue (e.g. `special/gcc-ASAN`) by default
+  (#69, @bbolker).
+
 # foghorn 1.6.1
 
 ## Bug fixes

--- a/R/cran_queue.R
+++ b/R/cran_queue.R
@@ -44,6 +44,17 @@ parse_http_cran_incoming <- function(res_raw) {
     return(new_cran_q())
   }
 
+  ## the `special` folder contains sub-folders (one per special check,
+  ## e.g. `special/noLD`) rather than package tarballs directly; these
+  ## are expanded into their own queries by `expand_special_folders()`
+  ## before we get here, so any remaining directory entries (names
+  ## ending in "/") are not packages and must be dropped
+  res <- res[!grepl("/$", res$Name), , drop = FALSE]
+
+  if (identical(nrow(res), 0L)) {
+    return(new_cran_q())
+  }
+
   pkgs <- parse_pkg(res$Name)
   time <- as.POSIXct(res[["Last modified"]], tz = "Europe/Vienna")
   size <- res$Size
@@ -51,9 +62,40 @@ parse_http_cran_incoming <- function(res_raw) {
   new_cran_q(
     package = pkgs$package,
     version = pkgs$version,
-    cran_folder = basename(res_raw$url),
+    cran_folder = cran_folder_from_url(res_raw$url),
     time = time,
     size = size
+  )
+}
+
+## derive the folder name to report from the request URL, e.g.
+## ".../incoming/newbies/" -> "newbies" and
+## ".../incoming/special/noLD/" -> "special/noLD"
+cran_folder_from_url <- function(url) {
+  folder <- sub(".*/incoming/", "", url)
+  sub("/$", "", folder)
+}
+
+## the `special` folder is a directory of sub-folders (one per special
+## check) rather than a folder of package tarballs; discover its
+## sub-folders and replace `"special"` with `"special/<sub-folder>"`
+## for each of them so that `cran_queue()` fetches the actual package
+## listings
+expand_special_folders <- function(folders, url) {
+  if (!("special" %in% folders)) {
+    return(folders)
+  }
+
+  res <- curl::curl_fetch_memory(paste0(url, "/special/"))
+  res <- xml2::read_html(rawToChar(res$content))
+  res <- rvest::html_table(res)[[1]]
+
+  sub_folders <- res$Name[nzchar(res$Name) & res$Name != "Parent Directory"]
+  sub_folders <- sub("/$", "", sub_folders)
+
+  c(
+    folders[folders != "special"],
+    paste0("special/", sub_folders)
   )
 }
 
@@ -85,6 +127,8 @@ cran_queue <- function(pkg, folders, url) {
   ) {
     stop(sQuote("pkg"), " must be a character vector.", call. = FALSE)
   }
+
+  folders <- expand_special_folders(folders, url)
 
   sub_folders <- paste0(folders, "/")
 
@@ -132,9 +176,9 @@ cran_queue <- function(pkg, folders, url) {
 ##' you track your package submission. Only the following folders are
 ##' considered (approximately in order of the CRAN queue sequence):
 ##' `newbies`, `inspect`, `pretest`, `recheck`, `pending`, `waiting`,
-##' `publish`. The folder `archive` is not inspected by default. The
-##' folders named after the initials of the CRAN volunteers are not
-##' inspected.
+##' `publish`, `special`. The folder `archive` is not inspected by
+##' default. The folders named after the initials of the CRAN
+##' volunteers are not inspected.
 ##'
 ##' @note
 ##' The meaning of the package folders is as follows
@@ -147,6 +191,7 @@ cran_queue <- function(pkg, folders, url) {
 ##' \item{pending}{a CRAN team member has to do a closer inspection and needs more time}
 ##' \item{waiting}{CRAN's decision is waiting for a response from the package maintainer, e.g. when issues are present that CRAN cannot check for in the incoming checks}
 ##' \item{publish}{package is awaiting publication}
+##' \item{special}{package is undergoing an additional, non-standard check (e.g. `noLD`, `valgrind`, `gcc-san`); unlike the other folders, `special` itself contains one sub-folder per check, so packages found here are reported with a `cran_folder` of the form `special/<check>`, e.g. `special/noLD`}
 ##' \item{archive}{package rejected: it does not pass the checks cleanly and the problems are unlikely to be false positives}
 ##' }
 ##'
@@ -242,7 +287,8 @@ cran_incoming_folders <- function(include_archive = FALSE) {
     "recheck",
     "pending",
     "publish",
-    "waiting"
+    "waiting",
+    "special"
   )
 
   if (include_archive) {

--- a/man/cran_incoming.Rd
+++ b/man/cran_incoming.Rd
@@ -51,9 +51,9 @@ and the folder where they are located. This information could help
 you track your package submission. Only the following folders are
 considered (approximately in order of the CRAN queue sequence):
 \code{newbies}, \code{inspect}, \code{pretest}, \code{recheck}, \code{pending}, \code{waiting},
-\code{publish}. The folder \code{archive} is not inspected by default. The
-folders named after the initials of the CRAN volunteers are not
-inspected.
+\code{publish}, \code{special}. The folder \code{archive} is not inspected by
+default. The folders named after the initials of the CRAN
+volunteers are not inspected.
 }
 \note{
 The meaning of the package folders is as follows
@@ -66,6 +66,7 @@ The meaning of the package folders is as follows
 \item{pending}{a CRAN team member has to do a closer inspection and needs more time}
 \item{waiting}{CRAN's decision is waiting for a response from the package maintainer, e.g. when issues are present that CRAN cannot check for in the incoming checks}
 \item{publish}{package is awaiting publication}
+\item{special}{package is undergoing an additional, non-standard check (e.g. \code{noLD}, \code{valgrind}, \code{gcc-san}); unlike the other folders, \code{special} itself contains one sub-folder per check, so packages found here are reported with a \code{cran_folder} of the form \verb{special/<check>}, e.g. \code{special/noLD}}
 \item{archive}{package rejected: it does not pass the checks cleanly and the problems are unlikely to be false positives}
 }
 }

--- a/tests/testthat/test-incoming.R
+++ b/tests/testthat/test-incoming.R
@@ -86,11 +86,22 @@ test_that("handling of misformed package name works", {
 })
 
 test_that("cran_incoming_folders works as expected", {
-  expect_identical(length(cran_incoming_folders()), 7L)
+  expect_identical(length(cran_incoming_folders()), 8L)
   expect_false(any(grepl("archive", cran_incoming_folders())))
-  expect_identical(length(cran_incoming_folders(include_archive = TRUE)), 8L)
+  expect_identical(length(cran_incoming_folders(include_archive = TRUE)), 9L)
   expect_true(any(grepl(
     "archive",
     cran_incoming_folders(include_archive = TRUE)
   )))
+})
+
+test_that("special folder is expanded into sub-folders", {
+  skip_on_cran()
+  skip_on_ci()
+
+  res <- cran_incoming(folders = "special")
+  expect_true(all(nzchar(res$package)))
+  expect_false(any(grepl("^special$", res$cran_folder)))
+  ## packages found in `special` should be reported as `special/<subfolder>`
+  expect_true(all(grepl("^special/", res$cran_folder) | nrow(res) == 0))
 })


### PR DESCRIPTION
This is Claude-assisted.

I have a package that is currently undergoing ASAN/valgrind checks, which means it lives in a subdirectory in the queue (e.g. `special/gcc-ASAN`). This includes those special folders in the `cran_incoming()` list by default (not many packages get checked this way, so it won't change results very much - e.g. it won't swamp the existing lists with additional stuff).
