### PR TITLE
Fix flaky compact summary test

### DIFF
--- a/tests/testthat/test-foghorn.R
+++ b/tests/testthat/test-foghorn.R
@@ -557,9 +557,17 @@ test_that("output of summary cran results", {
     build_regexp("with other issues", pkg_with_issues)
   )
 
-  msg <- capture_messages(summary_cran_results(pkg = "rncl", compact = TRUE))
+  ## use a package known to have issues so the compact/non-compact
+  ## formatting is exercised (a hard-coded package may become all-clear
+  ## on CRAN, in which case only the "All clear" message is emitted)
+  pkg_compact <- pkg_with_issues[[1]]
+  msg <- capture_messages(
+    summary_cran_results(pkg = pkg_compact, compact = TRUE)
+  )
   expect_false(all(grepl("  -", msg)))
-  msg <- capture_messages(summary_cran_results(pkg = "rncl", compact = FALSE))
+  msg <- capture_messages(
+    summary_cran_results(pkg = pkg_compact, compact = FALSE)
+  )
   expect_true(all(grepl("  -", msg)))
 })
 


### PR DESCRIPTION
## Problem

`test-foghorn.R` (the `compact` assertions in "output of summary cran results") hard-coded the package `rncl` and assumed it always has issues on CRAN. `rncl` is now all-clear, so `summary_cran_results()` emits only the `✔ All clear for rncl!` message, which lacks the `  - ` list prefix. This makes `expect_true(all(grepl("  -", msg)))` fail.

## Fix

Use a package drawn from the already-fetched CRAN issues data (`pkg_with_issues[[1]]`) instead of a hard-coded name, so the compact / non-compact formatting is reliably exercised regardless of any single package's current CRAN state.

Verified locally with `NOT_CRAN=true`: the full `test-foghorn.R` file passes (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)